### PR TITLE
Add Google Colab pip instructions

### DIFF
--- a/chapter01/Chapter 1 - Introduction to Language Models.ipynb
+++ b/chapter01/Chapter 1 - Introduction to Language Models.ipynb
@@ -27,6 +27,37 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install transformers>=4.40.1 accelerate>=0.27.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "hXp09JFsFBXi"
    },

--- a/chapter02/Chapter 2 - Tokens and Token Embeddings.ipynb
+++ b/chapter02/Chapter 2 - Tokens and Token Embeddings.ipynb
@@ -27,6 +27,32 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install transformers>=4.41.2 sentence-transformers>=3.0.1 gensim>=4.3.2 scikit-learn>=1.5.0 accelerate>=0.31.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "oQHfpqT_t9-K"
    },

--- a/chapter03/Chapter 3 - Looking Inside LLMs.ipynb
+++ b/chapter03/Chapter 3 - Looking Inside LLMs.ipynb
@@ -26,6 +26,32 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install transformers>=4.41.2 accelerate>=0.31.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "W_23Z_do-faF"
    },
@@ -862,7 +888,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/chapter04/Chapter 4 - Text Classification.ipynb
+++ b/chapter04/Chapter 4 - Text Classification.ipynb
@@ -26,6 +26,33 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install datasets transformers sentence-transformers openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "UBeVnXxQWy7-"
    },
@@ -1067,7 +1094,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/chapter05/Chapter 5 - Text Clustering and Topic Modeling.ipynb
+++ b/chapter05/Chapter 5 - Text Clustering and Topic Modeling.ipynb
@@ -26,6 +26,32 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install bertopic datasets openai datamapplot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "lHIkQSBkV2Y3"
    },

--- a/chapter06/Chapter 6 - Prompt Engineering.ipynb
+++ b/chapter06/Chapter 6 - Prompt Engineering.ipynb
@@ -26,6 +26,33 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install langchain>=0.1.17 openai>=1.13.3 langchain_openai>=0.1.6 transformers>=4.40.1 datasets>=2.18.0 accelerate>=0.27.2 sentence-transformers>=2.5.1 duckduckgo-search>=5.2.2\n",
+    "# !CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" pip install llama-cpp-python"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "KaB0B1LdMcPM"
    },
@@ -1264,7 +1291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/chapter07/Chapter 7 - Advanced Text Generation Techniques and Tools.ipynb
+++ b/chapter07/Chapter 7 - Advanced Text Generation Techniques and Tools.ipynb
@@ -26,6 +26,33 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install langchain>=0.1.17 openai>=1.13.3 langchain_openai>=0.1.6 transformers>=4.40.1 datasets>=2.18.0 accelerate>=0.27.2 sentence-transformers>=2.5.1 duckduckgo-search>=5.2.2 langchain_community\n",
+    "# !CMAKE_ARGS=\"-DLLAMA_CUDA=on\" pip install llama-cpp-python==0.2.69"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "rerbJgwAigbK"
    },

--- a/chapter08/Chapter 8 - Semantic Search.ipynb
+++ b/chapter08/Chapter 8 - Semantic Search.ipynb
@@ -26,6 +26,33 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install langchain==0.2.5 faiss-gpu==1.7.2 cohere==5.5.8 langchain-community==0.2.5 rank_bm25==0.2.2 sentence-transformers==3.0.1\n",
+    "# !CMAKE_ARGS=\"-DLLAMA_CUDA=on\" pip install llama-cpp-python==0.2.78"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "Ye0HbBr3EV0P"
    },
@@ -1899,7 +1926,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/chapter09/Chapter 9 - Multimodal Large Language Models.ipynb
+++ b/chapter09/Chapter 9 - Multimodal Large Language Models.ipynb
@@ -26,6 +26,32 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install matplotlib transformers datasets accelerate sentence-transformers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "NMF9p8qK58Ou"
    },
@@ -2623,7 +2649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/chapter10/Chapter 10 - Creating Text Embedding Models.ipynb
+++ b/chapter10/Chapter 10 - Creating Text Embedding Models.ipynb
@@ -26,6 +26,33 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install -q accelerate>=0.27.2 peft>=0.9.0 bitsandbytes>=0.43.0 transformers>=4.38.2 trl>=0.7.11 sentencepiece>=0.1.99\n",
+    "# !pip install -q sentence-transformers>=3.0.0 mteb>=1.1.2 datasets>=2.18.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "2UrKluX5YNmu"
    },
@@ -2703,7 +2730,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/chapter11/Chapter 11 - Fine-Tuning BERT.ipynb
+++ b/chapter11/Chapter 11 - Fine-Tuning BERT.ipynb
@@ -26,6 +26,32 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install datasets>=2.18.0 transformers>=4.38.2 sentence-transformers>=2.5.1 setfit>=1.0.3 accelerate>=0.27.2 seqeval>=1.2.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "UBeVnXxQWy7-"
    },
@@ -3593,7 +3619,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/chapter12/Chapter 12 - Fine-tuning Generation Models.ipynb
+++ b/chapter12/Chapter 12 - Fine-tuning Generation Models.ipynb
@@ -26,6 +26,32 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab (or any other cloud vendor), you need to **uncomment and run** the following codeblock to install the dependencies for this chapter:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "💡 **NOTE**: We will want to use a GPU to run the examples in this notebook. In Google Colab, go to\n",
+    "**Runtime > Change runtime type > Hardware accelerator > GPU > GPU type > T4**.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install -q accelerate peft bitsandbytes transformers trl sentencepiece"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "v5luSSUAu_6d"
    },
@@ -1952,7 +1978,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Adds instructions to install pypi packages in Google Colab since those seem to be missing. Although you could upload the `requirements.txt` to Colab, it's not the best user experience. Instead, I added an `[OPTIONAL]` section for Google Colab that starts with commented code. That way, users can just run it locally without needing to uncomment code and Google Colab can follow the instructions.   

This relates to #10 

Adds instructions like so:

![image](https://github.com/user-attachments/assets/d659126d-cce2-4ab3-932e-6139fb855f25)

@jalammar Those were the exact same instructions we had previously, so nothing was changed there. Can I go ahead and merge this? 