### PR TITLE
match tokenizer and model versions

### DIFF
--- a/chapter02/Chapter 2 - Tokens and Token Embeddings.ipynb
+++ b/chapter02/Chapter 2 - Tokens and Token Embeddings.ipynb
@@ -1610,7 +1610,7 @@
     "from transformers import AutoModel, AutoTokenizer\n",
     "\n",
     "# Load a tokenizer\n",
-    "tokenizer = AutoTokenizer.from_pretrained(\"microsoft/deberta-base\")\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"microsoft/deberta-v3-base\")\n",
     "\n",
     "# Load a language model\n",
     "model = AutoModel.from_pretrained(\"microsoft/deberta-v3-xsmall\")\n",


### PR DESCRIPTION
Match tokenizer and model versions:

- When looking at the papers, the vocab size of 'deberta-v3' is 128k whereas in 'deberta-base' was 50k, and the internal architectures have also some differences. This might lead to issues.
- Therefore it is proposed to update the tokenizer to 'microsoft/deberta-v3-base'