### PR TITLE
Fix #21

### DIFF
--- a/chapter09/Chapter 9 - Multimodal Large Language Models.ipynb
+++ b/chapter09/Chapter 9 - Multimodal Large Language Models.ipynb
@@ -1900,9 +1900,13 @@
     "import torch\n",
     "\n",
     "# Load processor and main model\n",
-    "blip_processor = AutoProcessor.from_pretrained(\"Salesforce/blip2-opt-2.7b\")\n",
+    "blip_processor = AutoProcessor.from_pretrained(\n",
+    "    \"Salesforce/blip2-opt-2.7b\",\n",
+    "    revision=\"51572668da0eb669e01a189dc22abe6088589a24\"  # Choose specific model because of: https://huggingface.co/Salesforce/blip2-opt-2.7b/discussions/39\n",
+    ")\n",
     "model = Blip2ForConditionalGeneration.from_pretrained(\n",
     "    \"Salesforce/blip2-opt-2.7b\",\n",
+    "    revision=\"51572668da0eb669e01a189dc22abe6088589a24\",\n",
     "    torch_dtype=torch.float16\n",
     ")\n",
     "\n",
@@ -2649,7 +2653,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Because of the discussion over here: https://huggingface.co/Salesforce/blip2-opt-2.7b/discussions/39
it seems that we need to pin the model version to make it fully reproducible. Newer versions might work but most likely require a more significant workaround. To minimize changes, pinning the revision maintains closer proximity to the book. 