### PR TITLE
Fixes #25, #26

### DIFF
--- a/chapter08/Chapter 8 - Semantic Search.ipynb
+++ b/chapter08/Chapter 8 - Semantic Search.ipynb
@@ -1448,7 +1448,7 @@
     }
    ],
    "source": [
-    "!wget https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf/resolve/main/Phi-3-mini-4k-instruct-fp16.gguf"
+    "!wget https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf/resolve/main/Phi-3-mini-4k-instruct-q4.gguf"
    ]
   },
   {
@@ -1463,7 +1463,7 @@
     "\n",
     "# Make sure the model path is correct for your system!\n",
     "llm = LlamaCpp(\n",
-    "    model_path=\"Phi-3-mini-4k-instruct-fp16.gguf\",\n",
+    "    model_path=\"Phi-3-mini-4k-instruct-q4.gguf\",\n",
     "    n_gpu_layers=-1,\n",
     "    max_tokens=500,\n",
     "    n_ctx=2048,\n",

--- a/chapter08/Chapter 8 - Semantic Search.ipynb
+++ b/chapter08/Chapter 8 - Semantic Search.ipynb
@@ -1783,7 +1783,7 @@
     "\n",
     "# Embedding Model for converting text to numerical representations\n",
     "embedding_model = HuggingFaceEmbeddings(\n",
-    "    model_name='thenlper/gte-small'\n",
+    "    model_name='BAAI/bge-small-en-v1.5'\n",
     ")"
    ]
   },


### PR DESCRIPTION
#25: replace 'Phi-3-mini-4k-instruct-fp16.gguf' by 'Phi-3-mini-4k-instruct-q4.gguf', the 4-bit quantized model version.

#26: replace 'thenlper/gte-small' by 'BAAI/bge-small-en-v1.5' to match the book model.
