### PR TITLE
fix: resolve Chapter 12 notebook compatibility with PyTorch 2.6.0 by …

### DIFF
--- a/chapter12/Chapter 12 - Fine-tuning Generation Models.ipynb
+++ b/chapter12/Chapter 12 - Fine-tuning Generation Models.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "# %%capture\n",
-    "# !pip install -q accelerate==0.31.0 peft==0.11.1 bitsandbytes==0.43.1 transformers==4.41.2 trl==0.9.4 sentencepiece==0.2.0"
+    "# !pip install -q accelerate==0.31.0 peft==0.11.1 bitsandbytes==0.43.1 transformers==4.41.2 trl==0.9.4 sentencepiece==0.2.0 triton==3.1.0"
    ]
   },
   {


### PR DESCRIPTION
…specifying triton package version

This update addresses the incompatibility issue in the Chapter 12 notebook when using PyTorch 2.6.0. Instead of downgrading PyTorch to 2.5.1, the solution involves installing a specific version of the triton package.

Fixes #41 