### PR TITLE
Chapter 2 - Fix imports

### DIFF
--- a/chapter02/Chapter 2 - Tokens and Token Embeddings.ipynb
+++ b/chapter02/Chapter 2 - Tokens and Token Embeddings.ipynb
@@ -48,7 +48,7 @@
    "outputs": [],
    "source": [
     "# %%capture\n",
-    "# !pip install transformers>=4.41.2 sentence-transformers>=3.0.1 gensim>=4.3.2 scikit-learn>=1.5.0 accelerate>=0.31.0"
+    "# !pip install --upgrade transformers==4.41.2 sentence-transformers==3.0.1 gensim==4.3.2 scikit-learn==1.5.0 accelerate==0.31.0 peft==0.11.1 scipy==1.10.1 numpy==1.26.4"
    ]
   },
   {


### PR DESCRIPTION
Relates to #38 and #66. It seems that gensim (or rather `triu` in `scipy` was dropped) and was in need for a more strict version control here. I was curious to see how far we can go relaxing the requirements in the Google Colab versions but it seems we have reached a limit. Although a fun experiment, it's time to restrict everything again and perhaps unify it (e.g., through `uv` and dependency groups for each chapter). 

Either way, here's a fix ;)