### PR TITLE
Update pip install command for transformers version

### DIFF
--- a/chapter01/Chapter 1 - Introduction to Language Models.ipynb
+++ b/chapter01/Chapter 1 - Introduction to Language Models.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "# %%capture\n",
-    "# !pip install transformers>=4.40.1 accelerate>=0.27.2"
+    "# !pip install transformers==4.40.2 accelerate>=0.27.2"
    ]
   },
   {

--- a/chapter01/Chapter 1 - Introduction to Language Models.ipynb
+++ b/chapter01/Chapter 1 - Introduction to Language Models.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "# %%capture\n",
-    "# !pip install transformers==4.40.2 accelerate>=0.27.2"
+    "# !pip install transformers==4.41.2 accelerate==0.31.0"
    ]
   },
   {


### PR DESCRIPTION
Fixing the version for transformers package as the newer versions generate error while trying to generate text. Replaced it with one of  the safest version options.