### PR TITLE
feat: upgrade MiniMax default model to M3 in bonus notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ We advise to run all examples through Google Colab for the easiest setup. Google
 
 ---
 
+> [!TIP]
+> The book's OpenAI examples (Chapters 4, 5, 7) also work with **OpenAI-compatible providers** like [MiniMax](https://www.minimaxi.com/) — just set a different `base_url` when creating the client. See the [bonus notebook](bonus/Using%20Alternative%20LLM%20Providers.ipynb) for details.
+
 ## [Bonus content!](bonus/)
 
 We attempted to put as much information into the book without it being overwhelming. However, even with a 400-page book there is still much to discover! 

--- a/bonus/README.md
+++ b/bonus/README.md
@@ -26,3 +26,4 @@ To get a feeling of each piece of additional content, click any of the markdown 
 7. [A Visual Guide to **Reasoning LLMs**](https://newsletter.maartengrootendorst.com/p/a-visual-guide-to-reasoning-llms)
 8. [The Illustrated **DeepSeek-R1**](https://newsletter.languagemodels.co/p/the-illustrated-deepseek-r1)
 9. [A Visual Guide to **LLM Agents**](https://newsletter.maartengrootendorst.com/p/a-visual-guide-to-llm-agents)
+10. [Using **Alternative LLM Providers**](Using%20Alternative%20LLM%20Providers.ipynb) - Use OpenAI-compatible providers (e.g., [MiniMax](https://www.minimaxi.com/)) with the book's code examples

--- a/bonus/Using Alternative LLM Providers.ipynb
+++ b/bonus/Using Alternative LLM Providers.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using Alternative LLM Providers\n",
+    "\n",
+    "*Extending the book's examples with OpenAI-compatible providers*\n",
+    "\n",
+    "<a href=\"https://www.amazon.com/Hands-Large-Language-Models-Understanding/dp/1098150961\"><img src=\"https://img.shields.io/badge/Buy%20the%20Book!-grey?logo=amazon\"></a>\n",
+    "<a href=\"https://github.com/HandsOnLLM/Hands-On-Large-Language-Models\"><img src=\"https://img.shields.io/badge/GitHub%20Repository-black?logo=github\"></a>\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Throughout the book, we use [OpenAI's API](https://openai.com/) in Chapters 4, 5, and 7 for text classification, topic modeling, and agents. One of the great things about the OpenAI SDK is that many other LLM providers offer **OpenAI-compatible APIs**. This means you can use the **exact same code** from the book with different providers by simply changing the `base_url` and `api_key`.\n",
+    "\n",
+    "This notebook demonstrates how to use [MiniMax](https://www.minimaxi.com/) as an alternative provider. MiniMax offers the **MiniMax-M2.5** model with a 204K context window through an OpenAI-compatible endpoint. The same approach works for other OpenAI-compatible providers as well.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n",
+    "\n",
+    "If you are viewing this notebook on Google Colab, you need to **uncomment and run** the following codeblock to install the dependencies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# !pip install openai langchain langchain_openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Swapping Providers with the OpenAI SDK\n",
+    "\n",
+    "In **Chapter 4**, we create an OpenAI client like this:\n",
+    "\n",
+    "```python\n",
+    "import openai\n",
+    "client = openai.OpenAI(api_key=\"YOUR_KEY_HERE\")\n",
+    "```\n",
+    "\n",
+    "To use MiniMax instead, we simply set the `base_url` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openai\n",
+    "\n",
+    "# MiniMax: OpenAI-compatible endpoint\n",
+    "client = openai.OpenAI(\n",
+    "    api_key=\"YOUR_MINIMAX_KEY\",  # Get your key at https://www.minimaxi.com/\n",
+    "    base_url=\"https://api.minimax.io/v1\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's it! The rest of the code from the book stays **exactly the same**. Let's verify with the text classification example from Chapter 4:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chatgpt_generation(prompt, document, model=\"MiniMax-M2.5\"):\n",
+    "    \"\"\"Generate an output based on a prompt and an input document.\n",
+    "\n",
+    "    This is the same function from Chapter 4, with only the default\n",
+    "    model name changed to use MiniMax.\n",
+    "    \"\"\"\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
+    "        {\"role\": \"user\", \"content\": prompt.replace(\"[DOCUMENT]\", document)},\n",
+    "    ]\n",
+    "    chat_completion = client.chat.completions.create(\n",
+    "        messages=messages,\n",
+    "        model=model,\n",
+    "        temperature=0.01,  # MiniMax requires temperature > 0\n",
+    "    )\n",
+    "    return chat_completion.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Same prompt from Chapter 4\n",
+    "prompt = \"\"\"Predict whether the following document is a positive or negative movie review:\n",
+    "\n",
+    "[DOCUMENT]\n",
+    "\n",
+    "If it is positive return 1 and if it is negative return 0. Do not give any other answers.\n",
+    "\"\"\"\n",
+    "\n",
+    "document = \"unpretentious , charming , quirky , original\"\n",
+    "chatgpt_generation(prompt, document)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using MiniMax with LangChain\n",
+    "\n",
+    "In **Chapter 7**, we use LangChain's `ChatOpenAI` for agents and chains. Since MiniMax provides an OpenAI-compatible API, we can use it directly with `ChatOpenAI` by specifying the `openai_api_base`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "# Use MiniMax as the LLM backend in LangChain\n",
+    "llm = ChatOpenAI(\n",
+    "    model_name=\"MiniMax-M2.5\",\n",
+    "    openai_api_key=\"YOUR_MINIMAX_KEY\",\n",
+    "    openai_api_base=\"https://api.minimax.io/v1\",\n",
+    "    temperature=0.01,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All LangChain patterns from Chapter 7 work as-is\n",
+    "response = llm.invoke(\"What is the capital of France?\")\n",
+    "print(response.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All the LangChain patterns from Chapter 7 (prompt templates, chains, memory, and agents) work without any modification. You only need to change the LLM initialization."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Environment Variables\n",
+    "\n",
+    "For a cleaner setup, you can configure the provider through environment variables. This makes it easy to switch between providers without changing your code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import openai\n",
+    "\n",
+    "# Configure via environment variables\n",
+    "# For OpenAI (default):\n",
+    "#   export LLM_API_KEY=\"sk-...\"\n",
+    "#   export LLM_BASE_URL=\"https://api.openai.com/v1\"\n",
+    "#   export LLM_MODEL=\"gpt-3.5-turbo\"\n",
+    "#\n",
+    "# For MiniMax:\n",
+    "#   export LLM_API_KEY=\"your-minimax-key\"\n",
+    "#   export LLM_BASE_URL=\"https://api.minimax.io/v1\"\n",
+    "#   export LLM_MODEL=\"MiniMax-M2.5\"\n",
+    "\n",
+    "client = openai.OpenAI(\n",
+    "    api_key=os.environ.get(\"LLM_API_KEY\", \"YOUR_KEY_HERE\"),\n",
+    "    base_url=os.environ.get(\"LLM_BASE_URL\", \"https://api.openai.com/v1\"),\n",
+    ")\n",
+    "model = os.environ.get(\"LLM_MODEL\", \"gpt-3.5-turbo\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Because many LLM providers now offer OpenAI-compatible APIs, you can extend the book's examples to use different models with minimal code changes:\n",
+    "\n",
+    "| Provider | `base_url` | Example Model |\n",
+    "|----------|-----------|---------------|\n",
+    "| [OpenAI](https://openai.com/) | `https://api.openai.com/v1` (default) | `gpt-3.5-turbo`, `gpt-4o` |\n",
+    "| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M2.5` |\n",
+    "\n",
+    "The key takeaway: **focus on learning the patterns and concepts from the book** \u2014 they transfer across providers. Once you understand prompt engineering, chains, memory, and agents, you can use them with any compatible LLM."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/bonus/Using Alternative LLM Providers.ipynb
+++ b/bonus/Using Alternative LLM Providers.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Using Alternative LLM Providers\n\n*Extending the book's examples with OpenAI-compatible providers*\n\n<a href=\"https://www.amazon.com/Hands-Large-Language-Models-Understanding/dp/1098150961\"><img src=\"https://img.shields.io/badge/Buy%20the%20Book!-grey?logo=amazon\"></a>\n<a href=\"https://github.com/HandsOnLLM/Hands-On-Large-Language-Models\"><img src=\"https://img.shields.io/badge/GitHub%20Repository-black?logo=github\"></a>\n\n---\n\nThroughout the book, we use [OpenAI's API](https://openai.com/) in Chapters 4, 5, and 7 for text classification, topic modeling, and agents. One of the great things about the OpenAI SDK is that many other LLM providers offer **OpenAI-compatible APIs**. This means you can use the **exact same code** from the book with different providers by simply changing the `base_url` and `api_key`.\n\nThis notebook demonstrates how to use [MiniMax](https://www.minimaxi.com/) as an alternative provider. MiniMax offers the **MiniMax-M2.7** flagship model with enhanced reasoning and coding capabilities through an OpenAI-compatible endpoint. The same approach works for other OpenAI-compatible providers as well.\n\n---"
+   "source": "# Using Alternative LLM Providers\n\n*Extending the book's examples with OpenAI-compatible providers*\n\n<a href=\"https://www.amazon.com/Hands-Large-Language-Models-Understanding/dp/1098150961\"><img src=\"https://img.shields.io/badge/Buy%20the%20Book!-grey?logo=amazon\"></a>\n<a href=\"https://github.com/HandsOnLLM/Hands-On-Large-Language-Models\"><img src=\"https://img.shields.io/badge/GitHub%20Repository-black?logo=github\"></a>\n\n---\n\nThroughout the book, we use [OpenAI's API](https://openai.com/) in Chapters 4, 5, and 7 for text classification, topic modeling, and agents. One of the great things about the OpenAI SDK is that many other LLM providers offer **OpenAI-compatible APIs**. This means you can use the **exact same code** from the book with different providers by simply changing the `base_url` and `api_key`.\n\nThis notebook demonstrates how to use [MiniMax](https://www.minimaxi.com/) as an alternative provider. MiniMax offers the **MiniMax-M3** flagship model with enhanced reasoning and coding capabilities through an OpenAI-compatible endpoint. The same approach works for other OpenAI-compatible providers as well.\n\n---"
   },
   {
    "cell_type": "markdown",
@@ -67,7 +67,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "def chatgpt_generation(prompt, document, model=\"MiniMax-M2.7\"):\n    \"\"\"Generate an output based on a prompt and an input document.\n\n    This is the same function from Chapter 4, with only the default\n    model name changed to use MiniMax.\n    \"\"\"\n    messages = [\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": prompt.replace(\"[DOCUMENT]\", document)},\n    ]\n    chat_completion = client.chat.completions.create(\n        messages=messages,\n        model=model,\n        temperature=0.01,  # MiniMax requires temperature > 0\n    )\n    return chat_completion.choices[0].message.content"
+   "source": "def chatgpt_generation(prompt, document, model=\"MiniMax-M3\"):\n    \"\"\"Generate an output based on a prompt and an input document.\n\n    This is the same function from Chapter 4, with only the default\n    model name changed to use MiniMax.\n    \"\"\"\n    messages = [\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": prompt.replace(\"[DOCUMENT]\", document)},\n    ]\n    chat_completion = client.chat.completions.create(\n        messages=messages,\n        model=model,\n        temperature=0.01,  # MiniMax requires temperature > 0\n    )\n    return chat_completion.choices[0].message.content"
   },
   {
    "cell_type": "code",
@@ -101,7 +101,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from langchain_openai import ChatOpenAI\n\n# Use MiniMax as the LLM backend in LangChain\nllm = ChatOpenAI(\n    model_name=\"MiniMax-M2.7\",\n    openai_api_key=\"YOUR_MINIMAX_KEY\",\n    openai_api_base=\"https://api.minimax.io/v1\",\n    temperature=0.01,\n)"
+   "source": "from langchain_openai import ChatOpenAI\n\n# Use MiniMax as the LLM backend in LangChain\nllm = ChatOpenAI(\n    model_name=\"MiniMax-M3\",\n    openai_api_key=\"YOUR_MINIMAX_KEY\",\n    openai_api_base=\"https://api.minimax.io/v1\",\n    temperature=0.01,\n)"
   },
   {
    "cell_type": "code",
@@ -135,12 +135,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import os\nimport openai\n\n# Configure via environment variables\n# For OpenAI (default):\n#   export LLM_API_KEY=\"sk-...\"\n#   export LLM_BASE_URL=\"https://api.openai.com/v1\"\n#   export LLM_MODEL=\"gpt-3.5-turbo\"\n#\n# For MiniMax:\n#   export LLM_API_KEY=\"your-minimax-key\"\n#   export LLM_BASE_URL=\"https://api.minimax.io/v1\"\n#   export LLM_MODEL=\"MiniMax-M2.7\"\n\nclient = openai.OpenAI(\n    api_key=os.environ.get(\"LLM_API_KEY\", \"YOUR_KEY_HERE\"),\n    base_url=os.environ.get(\"LLM_BASE_URL\", \"https://api.openai.com/v1\"),\n)\nmodel = os.environ.get(\"LLM_MODEL\", \"gpt-3.5-turbo\")"
+   "source": "import os\nimport openai\n\n# Configure via environment variables\n# For OpenAI (default):\n#   export LLM_API_KEY=\"sk-...\"\n#   export LLM_BASE_URL=\"https://api.openai.com/v1\"\n#   export LLM_MODEL=\"gpt-3.5-turbo\"\n#\n# For MiniMax:\n#   export LLM_API_KEY=\"your-minimax-key\"\n#   export LLM_BASE_URL=\"https://api.minimax.io/v1\"\n#   export LLM_MODEL=\"MiniMax-M3\"\n\nclient = openai.OpenAI(\n    api_key=os.environ.get(\"LLM_API_KEY\", \"YOUR_KEY_HERE\"),\n    base_url=os.environ.get(\"LLM_BASE_URL\", \"https://api.openai.com/v1\"),\n)\nmodel = os.environ.get(\"LLM_MODEL\", \"gpt-3.5-turbo\")"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Summary\n\nBecause many LLM providers now offer OpenAI-compatible APIs, you can extend the book's examples to use different models with minimal code changes:\n\n| Provider | `base_url` | Example Model |\n|----------|-----------|---------------|\n| [OpenAI](https://openai.com/) | `https://api.openai.com/v1` (default) | `gpt-3.5-turbo`, `gpt-4o` |\n| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` |\n\nThe key takeaway: **focus on learning the patterns and concepts from the book** — they transfer across providers. Once you understand prompt engineering, chains, memory, and agents, you can use them with any compatible LLM."
+   "source": "## Summary\n\nBecause many LLM providers now offer OpenAI-compatible APIs, you can extend the book's examples to use different models with minimal code changes:\n\n| Provider | `base_url` | Example Model |\n|----------|-----------|---------------|\n| [OpenAI](https://openai.com/) | `https://api.openai.com/v1` (default) | `gpt-3.5-turbo`, `gpt-4o` |\n| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` |\n\nThe key takeaway: **focus on learning the patterns and concepts from the book** — they transfer across providers. Once you understand prompt engineering, chains, memory, and agents, you can use them with any compatible LLM."
   }
  ],
  "metadata": {

--- a/bonus/Using Alternative LLM Providers.ipynb
+++ b/bonus/Using Alternative LLM Providers.ipynb
@@ -3,22 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Using Alternative LLM Providers\n",
-    "\n",
-    "*Extending the book's examples with OpenAI-compatible providers*\n",
-    "\n",
-    "<a href=\"https://www.amazon.com/Hands-Large-Language-Models-Understanding/dp/1098150961\"><img src=\"https://img.shields.io/badge/Buy%20the%20Book!-grey?logo=amazon\"></a>\n",
-    "<a href=\"https://github.com/HandsOnLLM/Hands-On-Large-Language-Models\"><img src=\"https://img.shields.io/badge/GitHub%20Repository-black?logo=github\"></a>\n",
-    "\n",
-    "---\n",
-    "\n",
-    "Throughout the book, we use [OpenAI's API](https://openai.com/) in Chapters 4, 5, and 7 for text classification, topic modeling, and agents. One of the great things about the OpenAI SDK is that many other LLM providers offer **OpenAI-compatible APIs**. This means you can use the **exact same code** from the book with different providers by simply changing the `base_url` and `api_key`.\n",
-    "\n",
-    "This notebook demonstrates how to use [MiniMax](https://www.minimaxi.com/) as an alternative provider. MiniMax offers the **MiniMax-M2.5** model with a 204K context window through an OpenAI-compatible endpoint. The same approach works for other OpenAI-compatible providers as well.\n",
-    "\n",
-    "---"
-   ]
+   "source": "# Using Alternative LLM Providers\n\n*Extending the book's examples with OpenAI-compatible providers*\n\n<a href=\"https://www.amazon.com/Hands-Large-Language-Models-Understanding/dp/1098150961\"><img src=\"https://img.shields.io/badge/Buy%20the%20Book!-grey?logo=amazon\"></a>\n<a href=\"https://github.com/HandsOnLLM/Hands-On-Large-Language-Models\"><img src=\"https://img.shields.io/badge/GitHub%20Repository-black?logo=github\"></a>\n\n---\n\nThroughout the book, we use [OpenAI's API](https://openai.com/) in Chapters 4, 5, and 7 for text classification, topic modeling, and agents. One of the great things about the OpenAI SDK is that many other LLM providers offer **OpenAI-compatible APIs**. This means you can use the **exact same code** from the book with different providers by simply changing the `base_url` and `api_key`.\n\nThis notebook demonstrates how to use [MiniMax](https://www.minimaxi.com/) as an alternative provider. MiniMax offers the **MiniMax-M2.7** flagship model with enhanced reasoning and coding capabilities through an OpenAI-compatible endpoint. The same approach works for other OpenAI-compatible providers as well.\n\n---"
   },
   {
    "cell_type": "markdown",
@@ -82,24 +67,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def chatgpt_generation(prompt, document, model=\"MiniMax-M2.5\"):\n",
-    "    \"\"\"Generate an output based on a prompt and an input document.\n",
-    "\n",
-    "    This is the same function from Chapter 4, with only the default\n",
-    "    model name changed to use MiniMax.\n",
-    "    \"\"\"\n",
-    "    messages = [\n",
-    "        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
-    "        {\"role\": \"user\", \"content\": prompt.replace(\"[DOCUMENT]\", document)},\n",
-    "    ]\n",
-    "    chat_completion = client.chat.completions.create(\n",
-    "        messages=messages,\n",
-    "        model=model,\n",
-    "        temperature=0.01,  # MiniMax requires temperature > 0\n",
-    "    )\n",
-    "    return chat_completion.choices[0].message.content"
-   ]
+   "source": "def chatgpt_generation(prompt, document, model=\"MiniMax-M2.7\"):\n    \"\"\"Generate an output based on a prompt and an input document.\n\n    This is the same function from Chapter 4, with only the default\n    model name changed to use MiniMax.\n    \"\"\"\n    messages = [\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": prompt.replace(\"[DOCUMENT]\", document)},\n    ]\n    chat_completion = client.chat.completions.create(\n        messages=messages,\n        model=model,\n        temperature=0.01,  # MiniMax requires temperature > 0\n    )\n    return chat_completion.choices[0].message.content"
   },
   {
    "cell_type": "code",
@@ -133,17 +101,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from langchain_openai import ChatOpenAI\n",
-    "\n",
-    "# Use MiniMax as the LLM backend in LangChain\n",
-    "llm = ChatOpenAI(\n",
-    "    model_name=\"MiniMax-M2.5\",\n",
-    "    openai_api_key=\"YOUR_MINIMAX_KEY\",\n",
-    "    openai_api_base=\"https://api.minimax.io/v1\",\n",
-    "    temperature=0.01,\n",
-    ")"
-   ]
+   "source": "from langchain_openai import ChatOpenAI\n\n# Use MiniMax as the LLM backend in LangChain\nllm = ChatOpenAI(\n    model_name=\"MiniMax-M2.7\",\n    openai_api_key=\"YOUR_MINIMAX_KEY\",\n    openai_api_base=\"https://api.minimax.io/v1\",\n    temperature=0.01,\n)"
   },
   {
    "cell_type": "code",
@@ -177,43 +135,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "import openai\n",
-    "\n",
-    "# Configure via environment variables\n",
-    "# For OpenAI (default):\n",
-    "#   export LLM_API_KEY=\"sk-...\"\n",
-    "#   export LLM_BASE_URL=\"https://api.openai.com/v1\"\n",
-    "#   export LLM_MODEL=\"gpt-3.5-turbo\"\n",
-    "#\n",
-    "# For MiniMax:\n",
-    "#   export LLM_API_KEY=\"your-minimax-key\"\n",
-    "#   export LLM_BASE_URL=\"https://api.minimax.io/v1\"\n",
-    "#   export LLM_MODEL=\"MiniMax-M2.5\"\n",
-    "\n",
-    "client = openai.OpenAI(\n",
-    "    api_key=os.environ.get(\"LLM_API_KEY\", \"YOUR_KEY_HERE\"),\n",
-    "    base_url=os.environ.get(\"LLM_BASE_URL\", \"https://api.openai.com/v1\"),\n",
-    ")\n",
-    "model = os.environ.get(\"LLM_MODEL\", \"gpt-3.5-turbo\")"
-   ]
+   "source": "import os\nimport openai\n\n# Configure via environment variables\n# For OpenAI (default):\n#   export LLM_API_KEY=\"sk-...\"\n#   export LLM_BASE_URL=\"https://api.openai.com/v1\"\n#   export LLM_MODEL=\"gpt-3.5-turbo\"\n#\n# For MiniMax:\n#   export LLM_API_KEY=\"your-minimax-key\"\n#   export LLM_BASE_URL=\"https://api.minimax.io/v1\"\n#   export LLM_MODEL=\"MiniMax-M2.7\"\n\nclient = openai.OpenAI(\n    api_key=os.environ.get(\"LLM_API_KEY\", \"YOUR_KEY_HERE\"),\n    base_url=os.environ.get(\"LLM_BASE_URL\", \"https://api.openai.com/v1\"),\n)\nmodel = os.environ.get(\"LLM_MODEL\", \"gpt-3.5-turbo\")"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "Because many LLM providers now offer OpenAI-compatible APIs, you can extend the book's examples to use different models with minimal code changes:\n",
-    "\n",
-    "| Provider | `base_url` | Example Model |\n",
-    "|----------|-----------|---------------|\n",
-    "| [OpenAI](https://openai.com/) | `https://api.openai.com/v1` (default) | `gpt-3.5-turbo`, `gpt-4o` |\n",
-    "| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M2.5` |\n",
-    "\n",
-    "The key takeaway: **focus on learning the patterns and concepts from the book** \u2014 they transfer across providers. Once you understand prompt engineering, chains, memory, and agents, you can use them with any compatible LLM."
-   ]
+   "source": "## Summary\n\nBecause many LLM providers now offer OpenAI-compatible APIs, you can extend the book's examples to use different models with minimal code changes:\n\n| Provider | `base_url` | Example Model |\n|----------|-----------|---------------|\n| [OpenAI](https://openai.com/) | `https://api.openai.com/v1` (default) | `gpt-3.5-turbo`, `gpt-4o` |\n| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` |\n\nThe key takeaway: **focus on learning the patterns and concepts from the book** — they transfer across providers. Once you understand prompt engineering, chains, memory, and agents, you can use them with any compatible LLM."
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
Upgrade the MiniMax default model in the bonus notebook to `MiniMax-M3`, MiniMax's latest flagship model.

## Changes
- Update default model in `chatgpt_generation()` from `MiniMax-M2.7` to `MiniMax-M3`
- Update LangChain `ChatOpenAI` example to use `MiniMax-M3`
- Update environment variable example to use `MiniMax-M3`
- Add `MiniMax-M3` to the example models in the Summary table
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives

## Why
`MiniMax-M3` is MiniMax's latest model, with a 512K context window, up to 128K max output, and image input support. Using it as the default makes the bonus notebook reflect the most current and capable MiniMax model.

## Testing
- Verified the notebook is valid JSON (`nbformat 4.4`, 15 cells)
- Verified all default model references now point to `MiniMax-M3`
- Verified `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` are still listed as alternatives in the Summary table