### PR TITLE
fix: convert Dataset Column to list before SentenceTransformer.encode

### DIFF
--- a/chapter04/Chapter 4 - Text Classification.ipynb
+++ b/chapter04/Chapter 4 - Text Classification.ipynb
@@ -435,8 +435,10 @@
     "model = SentenceTransformer('sentence-transformers/all-mpnet-base-v2')\n",
     "\n",
     "# Convert text to embeddings\n",
-    "train_embeddings = model.encode(data[\"train\"][\"text\"], show_progress_bar=True)\n",
-    "test_embeddings = model.encode(data[\"test\"][\"text\"], show_progress_bar=True)"
+    "# Use list() to convert HuggingFace Dataset columns to plain lists,\n",
+    "# avoiding TypeError from numpy.int64 indexing on Column objects\n",
+    "train_embeddings = model.encode(list(data[\"train\"][\"text\"]), show_progress_bar=True)\n",
+    "test_embeddings = model.encode(list(data[\"test\"][\"text\"]), show_progress_bar=True)"
    ]
   },
   {


### PR DESCRIPTION
Fixes #79

## Problem

`SentenceTransformer.encode()` sorts input sentences by length internally using `numpy.int64` indices. HuggingFace `Dataset` column objects (e.g. `data["train"]["text"]`) do not support indexing with `numpy.int64`, which raises a `TypeError` during encode.

## Solution

Wrap the column with `list()` before passing it to `model.encode()`, converting it to a plain Python list that supports standard numpy indexing:

```python
# Before
train_embeddings = model.encode(data["train"]["text"], show_progress_bar=True)
test_embeddings  = model.encode(data["test"]["text"],  show_progress_bar=True)

# After
train_embeddings = model.encode(list(data["train"]["text"]), show_progress_bar=True)
test_embeddings  = model.encode(list(data["test"]["text"]),  show_progress_bar=True)
```

## Testing

The fix matches the workaround confirmed in the issue thread. The `list()` conversion has zero impact on encode results — it only changes the container type before sort-by-length occurs.