### PR TITLE
pin peft to 0.11.1 consistent with transformers 4.41.2 and requiremen…

### DIFF
--- a/chapter04/Chapter 4 - Text Classification.ipynb
+++ b/chapter04/Chapter 4 - Text Classification.ipynb
@@ -48,7 +48,7 @@
    "outputs": [],
    "source": [
     "# %%capture\n",
-    "# !pip install \"transformers==4.41.2\" \"sentence-transformers==3.0.1\" openai\n",
+    "# !pip install \"transformers==4.41.2\" \"sentence-transformers==3.0.1\" \"peft==0.11.1\" openai\n",
     "# !pip install -U datasets"
    ]
   },


### PR DESCRIPTION
…ts.txt

set peft to the same version as in requirements.txt ensuring compatibility with the transformers pinned version 4.41.2

(error occurs at `from sentence_transformers import SentenceTransformer`)

fixes https://github.com/HandsOnLLM/Hands-On-Large-Language-Models/issues/117