### PR TITLE
Add current MiniMax regional endpoint examples

### DIFF
--- a/bonus/README.md
+++ b/bonus/README.md
@@ -26,3 +26,4 @@ To get a feeling of each piece of additional content, click any of the markdown 
 7. [A Visual Guide to **Reasoning LLMs**](https://newsletter.maartengrootendorst.com/p/a-visual-guide-to-reasoning-llms)
 8. [The Illustrated **DeepSeek-R1**](https://newsletter.languagemodels.co/p/the-illustrated-deepseek-r1)
 9. [A Visual Guide to **LLM Agents**](https://newsletter.maartengrootendorst.com/p/a-visual-guide-to-llm-agents)
+10. [Using **MiniMax API Endpoints**](Using%20MiniMax%20API%20Endpoints.ipynb) - Configure MiniMax models across global and China endpoints

--- a/bonus/Using MiniMax API Endpoints.ipynb
+++ b/bonus/Using MiniMax API Endpoints.ipynb
@@ -1,0 +1,75 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# Using MiniMax API Endpoints\n\nThis notebook extends the API-backed generation patterns from Chapters 4 and 7 with MiniMax. It covers the OpenAI-compatible chat completions interface and the Anthropic-compatible messages interface in both supported regions.\n\nModel and endpoint selection stay in one executable configuration so the request cells do not need region-specific changes."
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "### [OPTIONAL] - Installing Packages on <img src=\"https://colab.google/static/images/icons/colab.png\" width=100>\n\nUncomment and run the following cell when the compatible client packages are not already installed."
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "# %%capture\n# !pip install openai anthropic"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Model Configuration\n\n| Model | Context window | Input modalities | Thinking modes |\n|-------|---------------:|------------------|----------------|\n| MiniMax-M3 | 1000000 | text, image, video | adaptive, disabled |\n| MiniMax-M2.7 | 204800 | text | always_on |\n\nPricing below is in USD per million tokens.\n\n| Model | Input | Output | Cache read | Cache write |\n|-------|------:|-------:|-----------:|------------:|\n| MiniMax-M3 | 0.6 | 2.4 | 0.12 | n/a |\n| MiniMax-M2.7 | 0.3 | 1.2 | 0.06 | 0.375 |"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "import json\nimport os\n\nfrom anthropic import Anthropic\nfrom openai import OpenAI\n\nMINIMAX_MODELS = json.loads(\"{\\\"MiniMax-M3\\\":{\\\"context_window\\\":1000000,\\\"pricing_usd_per_million_tokens\\\":{\\\"input\\\":0.6,\\\"output\\\":2.4,\\\"cache_read\\\":0.12,\\\"cache_write\\\":null},\\\"input_modalities\\\":[\\\"text\\\",\\\"image\\\",\\\"video\\\"],\\\"thinking\\\":[\\\"adaptive\\\",\\\"disabled\\\"]},\\\"MiniMax-M2.7\\\":{\\\"context_window\\\":204800,\\\"pricing_usd_per_million_tokens\\\":{\\\"input\\\":0.3,\\\"output\\\":1.2,\\\"cache_read\\\":0.06,\\\"cache_write\\\":0.375},\\\"input_modalities\\\":[\\\"text\\\"],\\\"thinking\\\":[\\\"always_on\\\"]}}\")\nMINIMAX_ENDPOINTS = json.loads(\"{\\\"global_en\\\":{\\\"openai_base_url\\\":\\\"https://api.minimax.io/v1\\\",\\\"anthropic_base_url\\\":\\\"https://api.minimax.io/anthropic\\\",\\\"docs_root\\\":\\\"https://platform.minimax.io/docs\\\"},\\\"cn_zh\\\":{\\\"openai_base_url\\\":\\\"https://api.minimaxi.com/v1\\\",\\\"anthropic_base_url\\\":\\\"https://api.minimaxi.com/anthropic\\\",\\\"docs_root\\\":\\\"https://platform.minimaxi.com/docs\\\"}}\")\n\nregion_name = os.environ.get(\"MINIMAX_REGION\", \"global_en\")\nmodel_id = os.environ.get(\"MINIMAX_MODEL\", \"MiniMax-M3\")\n\nif region_name not in MINIMAX_ENDPOINTS:\n    raise ValueError(f\"Unsupported MiniMax region: {region_name}\")\nif model_id not in MINIMAX_MODELS:\n    raise ValueError(f\"Unsupported MiniMax model: {model_id}\")\n\nendpoint = MINIMAX_ENDPOINTS[region_name]\nmodel_config = MINIMAX_MODELS[model_id]"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Chat Completions Interface\n\nThe selected region supplies the matching OpenAI-compatible base URL."
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "openai_client = OpenAI(\n    api_key=os.environ[\"MINIMAX_API_KEY\"],\n    base_url=endpoint[\"openai_base_url\"],\n)\n\nopenai_response = openai_client.chat.completions.create(\n    model=model_id,\n    messages=[\n        {\"role\": \"user\", \"content\": \"Explain context windows in one sentence.\"}\n    ],\n)\nprint(openai_response.choices[0].message.content)"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Messages Interface\n\nThe same model and region selection can be used with the Anthropic-compatible base URL."
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "anthropic_client = Anthropic(\n    api_key=os.environ[\"MINIMAX_API_KEY\"],\n    base_url=endpoint[\"anthropic_base_url\"],\n)\n\nanthropic_response = anthropic_client.messages.create(\n    model=model_id,\n    max_tokens=256,\n    messages=[\n        {\"role\": \"user\", \"content\": \"Explain context windows in one sentence.\"}\n    ],\n)\nprint(anthropic_response.content[0].text)"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Switching Configuration\n\nSet MINIMAX_REGION to global_en or cn_zh and MINIMAX_MODEL to MiniMax-M3 or MiniMax-M2.7, then rerun the configuration and request cells. The endpoint dictionary also exposes the matching documentation root."
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}


### PR DESCRIPTION
Reason: Add a complete MiniMax provider example with current models and regional endpoints.

## Changes

- Add an executable bonus notebook for MiniMax-M3 and MiniMax-M2.7 model metadata.
- Configure global and China endpoint pairs for both supported client interfaces.
- Add request examples that share the selected MiniMax model and region configuration.
- Link the notebook from the bonus material index.

## Checks

- `python3 -m json.tool 'bonus/Using MiniMax API Endpoints.ipynb'`
- `python3 -c 'import ast,json,pathlib; data=json.loads(pathlib.Path("bonus/Using MiniMax API Endpoints.ipynb").read_text()); assert data["nbformat"] == 4; [ast.parse(cell["source"] if isinstance(cell["source"], str) else "".join(cell["source"])) for cell in data["cells"] if cell["cell_type"] == "code"]'`
- `jq -e '([.cells[].source | if type == "array" then join("") else . end] | join("\n")) as $source | ["MiniMax-M3", "MiniMax-M2.7", "https://api.minimax.io/v1", "https://api.minimaxi.com/v1", "https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"] | all(. as $value | $source | contains($value))' 'bonus/Using MiniMax API Endpoints.ipynb'`
- `git diff --check`
